### PR TITLE
Ignore TypeScript major updates in Dependabot npm group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    # TypeScript 7 is not yet supported by @typescript-eslint (peer range <6.1.0);
+    # drop this once the toolchain supports TS 7 and migrate deliberately.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       frontend-dependencies:
         patterns:


### PR DESCRIPTION
TypeScript 7 conflicts with @typescript-eslint's peer range (`>=4.8.4 <6.1.0`), which broke the grouped frontend bump in #256 (npm ERESOLVE on install). This skips TypeScript semver-major updates in the npm group until the toolchain supports TS 7, at which point the migration should be done deliberately and this rule removed.