### PR TITLE
Bump unifi-topology from 2.2.2 to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped DOMPurify from 3.4.7 to 3.4.10 (maintenance releases: Trusted Types policy handling, node-iterator template-scrubbing, and IN_PLACE sanitization fixes) and rebuilt the frontend bundle (#229, #234, #239)
+- Bumped `unifi-topology` from 2.2.2 to 3.0.1 (#252). The 3.0 breaking changes (edge diff `entity_type`, `collapse_client_edges` return shape, snapshot version validation) do not affect this integration -- it uses none of those APIs. The error mapping now reads the HTTP status from the `status_code` attribute introduced on the `UnifiError` hierarchy, with the previous cause/message parsing kept as fallback. Upstream 3.0 also brings a default 30s HTTP timeout, fewer spurious diff events from wireless signal jitter, and no longer probes legacy controllers with a doomed UDM login on every fetch (reducing 429/lockout risk)
 
 ### Security
 - Cleared two Dependabot advisories in the frontend build/test toolchain (transitive dev dependencies; not part of the shipped card bundle): updated `@babel/core` to 7.29.7 (CVE-2026-49356, arbitrary file read via `sourceMappingURL`) and forced `js-yaml` to 4.2.0 via an npm override (CVE-2026-53550, quadratic-complexity DoS in merge-key handling). The vulnerable `js-yaml` 3.x was pinned by the unmaintained `@istanbuljs/load-nyc-config`; the override is verified against the Jest coverage run. `npm audit` now reports 0 vulnerabilities

--- a/custom_components/unifi_network_map/api.py
+++ b/custom_components/unifi_network_map/api.py
@@ -248,6 +248,9 @@ def _map_api_error(exc: Exception) -> UniFiNetworkMapError:
 
 
 def _status_code_from_exception(exc: Exception) -> int | None:
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
     cause = getattr(exc, "__cause__", None)
     if isinstance(cause, HTTPError) and cause.response is not None:
         return cause.response.status_code
@@ -255,11 +258,11 @@ def _status_code_from_exception(exc: Exception) -> int | None:
 
 
 def _unifi_api_status_code(exc: Exception) -> int | None:
-    """Extract the HTTP status from a UnifiApiError (cause or message).
+    """Extract the HTTP status from a UnifiApiError.
 
-    The upstream client raises ``UnifiApiError`` for failed data requests
-    with the status only in the message (``... failed (HTTP <code>)``);
-    the contract test locks that format.
+    Prefers the ``status_code`` attribute (unifi-topology >= 3.0), then the
+    ``HTTPError`` cause, then the ``... failed (HTTP <code>)`` message format
+    locked by the contract test.
     """
     cause_status = _status_code_from_exception(exc)
     if cause_status is not None:

--- a/custom_components/unifi_network_map/manifest.json
+++ b/custom_components/unifi_network_map/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/merlijntishauser/unifi-network-maps-ha/issues",
   "requirements": [
-    "unifi-topology==2.2.2"
+    "unifi-topology==3.0.1"
   ],
   "version": "0.5.5"
 }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -286,6 +286,30 @@ def test_unifi_api_status_code_parses_http_in_message() -> None:
     assert unifi_api_status_code(UnifiApiError("Missing 'data' field")) is None
 
 
+def test_unifi_api_status_code_prefers_status_code_attribute() -> None:
+    from unifi_topology.adapters.unifi_api import UnifiApiError
+
+    unifi_api_status_code = cast(
+        "Callable[[Exception], int | None]",
+        getattr(api_module, "_unifi_api_status_code"),
+    )
+
+    assert unifi_api_status_code(UnifiApiError("boom", status_code=403)) == 403
+
+
+def test_map_auth_error_rate_limit_from_status_code_attribute() -> None:
+    from unifi_topology.adapters.unifi_api import UnifiAuthError
+
+    map_auth_error = cast(
+        "Callable[[Exception], Exception]",
+        getattr(api_module, "_map_auth_error"),
+    )
+
+    mapped = map_auth_error(UnifiAuthError("boom", status_code=429))
+
+    assert isinstance(mapped, CannotConnect)
+
+
 def test_map_auth_error_falls_back_to_invalid_auth() -> None:
     map_auth_error = cast(
         "Callable[[Exception], Exception]",


### PR DESCRIPTION
Migrates the integration to unifi-topology 3.0.1 per the checklist in #252.

## Audit of 3.0 breaking changes
- **Edge diff `entity_type`**: not applicable -- the integration does not use `compare_topologies`/`TopologyDiff` (that is still open as #32).
- **`fetch_*` exception types**: already handled -- `api.py` catches `UnifiAuthError`/`UnifiApiError` first with `RequestException` as fallback. The status extraction now prefers the new `status_code` attribute on the `UnifiError` hierarchy, keeping the `HTTPError` cause and `(HTTP <code>)` message parsing as fallbacks (covered by new unit tests; the existing contract test still locks the message format).
- **`collapse_client_edges` return shape**: not used.
- **Snapshot `from_dict` version validation**: not used -- no snapshots are persisted.
- **MAC normalization**: the integration uses its own local `_normalize_mac`; payload MACs pass the full test suite unchanged.
- **Default 30s HTTP timeout**: verified `UNIFI_REQUEST_TIMEOUT_SECONDS` is still honored in 3.0.1 (`adapters/_retry.py`), so the configurable timeout keeps working; upstream's default is a safety net below it.

This also brings `requirements.txt` and `manifest.json` back in sync: a merged Dependabot pip-group PR had bumped `requirements.txt` to 3.0.1 without touching `manifest.json` (the source of truth HA installs from), so the `check-requirements` hook was failing on main.

All 564 tests pass (unit, integration, contract) plus the full pre-commit suite.

Closes #252